### PR TITLE
AC-5421: Extend framework to provide a more abstract heuristics interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,5 @@ help:
 
 
 code-check:
-	pycodestyle *.py */*.py
+	@pycodestyle *.py */*.py
+	@flake8 *.py */*.py

--- a/allocate.py
+++ b/allocate.py
@@ -9,31 +9,23 @@ import csv
 import sys
 from random import choice
 
-from classes.allocator import Allocator
-from classes.bin import BIN_DEFAULT_WEIGHT
-from classes.female_bin import FemaleBin
-from classes.home_program_bin import HomeProgramBin
-from classes.industry_bin import IndustryBin
-from classes.judge import Judge
-from classes.property import program
-from classes.property import industry
-from classes.reads_bin import ReadsBin
-from classes.role_bin import RoleBin
-from classes.satisfied_bin import SatisfiedBin
-from classes.startup import Startup
+from classes.allocator import (
+    Allocator,
+    RANDOM_SELECTION_HEURISTIC,
+)
 
+
+filename = None
+heuristic = RANDOM_SELECTION_HEURISTIC
 
 if len(sys.argv) > 1:
     filepath = sys.argv[1]
-else:
-    filepath = None
+if len(sys.argv) > 2:
+    heuristic = sys.argv[2]
 
 
-allocator = Allocator(filepath)
+allocator = Allocator(filepath, heuristic)
 allocator.read_entities()
-allocator.default_bins()
-allocator.add_startups()
-allocator.calc_capacity()
+allocator.setup()
 allocator.allocate()
-allocator.assess_allocations()
-allocator.assess_bins()
+allocator.assess()

--- a/allocate.py
+++ b/allocate.py
@@ -5,9 +5,7 @@
 
 # TODO: Output should be as a CSV that can then assessed by a new assess.py
 # script.
-import csv
 import sys
-from random import choice
 
 from classes.allocator import (
     Allocator,

--- a/allocate.py
+++ b/allocate.py
@@ -7,9 +7,7 @@
 # script.
 import sys
 
-from classes.allocator import (
-    Allocator,
-)
+from classes.allocator import Allocator
 from classes.event import Event
 
 

--- a/allocate.py
+++ b/allocate.py
@@ -9,13 +9,12 @@ import sys
 
 from classes.allocator import (
     Allocator,
-    RANDOM_SELECTION_HEURISTIC,
 )
 from classes.event import Event
 
 
 filename = None
-heuristic = RANDOM_SELECTION_HEURISTIC
+heuristic = ""
 
 if len(sys.argv) > 1:
     filepath = sys.argv[1]

--- a/allocate.py
+++ b/allocate.py
@@ -13,6 +13,7 @@ from classes.allocator import (
     Allocator,
     RANDOM_SELECTION_HEURISTIC,
 )
+from classes.event import Event
 
 
 filename = None
@@ -29,3 +30,6 @@ allocator.read_entities()
 allocator.setup()
 allocator.allocate()
 allocator.assess()
+
+for event in Event.all_events:
+    print (event.to_csv())

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -12,12 +12,11 @@ from random import choice
 from classes.event import Event
 from classes.heuristic import find_heuristic
 from classes.judge import Judge
-from classes.property import program
-from classes.property import industry
 from classes.startup import Startup
 
 
 RANDOM_SELECTION_HEURISTIC = ""
+
 
 class Allocator(object):
     def __init__(self, filepath, heuristic):

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -9,6 +9,7 @@ import csv
 import sys
 from random import choice
 
+from classes.assignments import assign
 from classes.event import Event
 from classes.heuristic import find_heuristic
 from classes.judge import Judge
@@ -45,7 +46,15 @@ class Allocator(object):
     def allocate(self):
         while self.heuristic.work_left() and self.judges:
             judge = choice(self.judges)
-            self.heuristic.next_action(judge)
+            self.heuristic.process_judge_events(judge.complete_startups())
+            while judge.needs_another_startup():
+                startup = self.heuristic.find_one_startup(judge)
+                if startup:
+                    assign(judge, startup)
+                else:
+                    break
+            if not judge.startups:
+                judge.mark_as_done()
             if judge.remaining <= 0 and not judge.startups:
                 self.judges.remove(judge)
 

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -47,16 +47,19 @@ class Allocator(object):
         while self.heuristic.work_left() and self.judges:
             judge = choice(self.judges)
             self.heuristic.process_judge_events(judge.complete_startups())
-            while judge.needs_another_startup():
-                startup = self.heuristic.find_one_startup(judge)
-                if startup:
-                    assign(judge, startup)
-                else:
-                    break
-            if not judge.startups:
-                judge.mark_as_done()
+            self.assign_startups(judge)
             if judge.remaining <= 0 and not judge.startups:
                 self.judges.remove(judge)
+
+    def assign_startups(self, judge):
+        while judge.needs_another_startup():
+            startup = self.heuristic.find_one_startup(judge)
+            if startup:
+                assign(judge, startup)
+            else:
+                break
+        if not judge.startups:
+            judge.mark_as_done()
 
     def assess(self):
         Event(action="done",

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -9,32 +9,22 @@ import csv
 import sys
 from random import choice
 
-from classes.bin import BIN_DEFAULT_WEIGHT
-from classes.female_bin import FemaleBin
-from classes.home_program_bin import HomeProgramBin
-from classes.industry_bin import IndustryBin
+from classes.heuristic import find_heuristic
 from classes.judge import Judge
 from classes.property import program
 from classes.property import industry
-from classes.reads_bin import ReadsBin
-from classes.role_bin import RoleBin
-from classes.satisfied_bin import SatisfiedBin
 from classes.startup import Startup
 
-FEMALE_WEIGHT = 2
-ROLE_WEIGHT = 3
-HOME_PROGRAM_WEIGHT = 4
-JUDGE_ZSCORE_WEIGHT = 5
-INDUSTRY_WEIGHT = 2
 
+RANDOM_SELECTION_HEURISTIC = ""
 
 class Allocator(object):
-    def __init__(self, filepath=None):
+    def __init__(self, filepath, heuristic):
         self.filepath = filepath
         self.judges = []
         self.startups = []
-        self.bins = []
         self.events = []
+        self.heuristic = find_heuristic(heuristic)
         self.ticks = 0
 
     def _file(self):
@@ -52,41 +42,13 @@ class Allocator(object):
                 elif row["type"] == "startup":
                     self.startups.append(Startup(data=row))
 
-    def add_startups(self):
-        for startup in self.startups:
-            for bin in self.bins:
-                bin.add_startup(startup)
-
-    def calc_capacity(self):
-        for bin in self.bins:
-            bin.calc_capacity(self.judges)
-
-    def work_left(self):
-        return any([bin.work_left() for bin in self.bins])
-
-    def default_bins(self):
-        self.bins = (
-            [ReadsBin(),
-             SatisfiedBin(),
-             FemaleBin(weight=FEMALE_WEIGHT*BIN_DEFAULT_WEIGHT),
-             RoleBin(value="Executive",
-                     weight=ROLE_WEIGHT*BIN_DEFAULT_WEIGHT,
-                     count=2),
-             RoleBin(value="Lawyer",
-                     weight=ROLE_WEIGHT*BIN_DEFAULT_WEIGHT),
-             RoleBin(value="Investor",
-                     weight=ROLE_WEIGHT*BIN_DEFAULT_WEIGHT)] +
-            bin_factory(IndustryBin,
-                        values=[value for value, _ in industry.values],
-                        weight=INDUSTRY_WEIGHT*BIN_DEFAULT_WEIGHT) +
-            bin_factory(HomeProgramBin,
-                        values=[value for value, _ in program.values],
-                        weight=HOME_PROGRAM_WEIGHT*BIN_DEFAULT_WEIGHT))
+    def setup(self):
+        self.heuristic.setup(self.judges, self.startups)
 
     def allocate(self):
-        while self.work_left() and self.judges:
+        while self.heuristic.work_left() and self.judges:
             judge = choice(self.judges)
-            judge.next_action(self.bins)
+            self.heuristic.next_action(judge)
             self.register_judge_events(judge)
             if not judge.has_more_work:
                 self.judges.remove(judge)
@@ -96,20 +58,12 @@ class Allocator(object):
         while judge.events:
             self.add_event(judge.events.pop(0))
 
-    def assess_allocations(self):
-        for event in self.events:
-            print (event.to_csv())
-        print("done,allocate.py,No more judges,")
-
-    def assess_bins(self):
-        for bin in self.bins:
-            bin.status()
-
     def add_event(self, event):
         event.update(time=self.ticks)
         self.events.append(event)
 
-
-def bin_factory(klass, values, weight):
-    return [klass(value=value, weight=weight)
-            for value in values]
+    def assess(self):
+        for event in self.events:
+            print (event.to_csv())
+        print("done,allocate.py,No more judges,")
+        self.heuristic.assess()

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -9,6 +9,7 @@ import csv
 import sys
 from random import choice
 
+from classes.event import Event
 from classes.heuristic import find_heuristic
 from classes.judge import Judge
 from classes.property import program
@@ -23,9 +24,7 @@ class Allocator(object):
         self.filepath = filepath
         self.judges = []
         self.startups = []
-        self.events = []
         self.heuristic = find_heuristic(heuristic)
-        self.ticks = 0
 
     def _file(self):
         if self.filepath is None:
@@ -49,21 +48,11 @@ class Allocator(object):
         while self.heuristic.work_left() and self.judges:
             judge = choice(self.judges)
             self.heuristic.next_action(judge)
-            self.register_judge_events(judge)
-            if not judge.has_more_work:
+            if judge.remaining <= 0 and not judge.startups:
                 self.judges.remove(judge)
-            self.ticks += 1
-
-    def register_judge_events(self, judge):
-        while judge.events:
-            self.add_event(judge.events.pop(0))
-
-    def add_event(self, event):
-        event.update(time=self.ticks)
-        self.events.append(event)
 
     def assess(self):
-        for event in self.events:
-            print (event.to_csv())
-        print("done,allocate.py,No more judges,")
+        Event(action="done",
+              subject="allocate.py",
+              description="No more judges")
         self.heuristic.assess()

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -15,15 +15,14 @@ from classes.judge import Judge
 from classes.startup import Startup
 
 
-RANDOM_SELECTION_HEURISTIC = ""
-
-
 class Allocator(object):
     def __init__(self, filepath, heuristic):
         self.filepath = filepath
         self.judges = []
         self.startups = []
         self.heuristic = find_heuristic(heuristic)
+        Event(action="heuristic",
+              subject=self.heuristic.name)
 
     def _file(self):
         if self.filepath is None:

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -50,6 +50,10 @@ class Allocator(object):
             self.assign_startups(judge)
             if judge.remaining <= 0 and not judge.startups:
                 self.judges.remove(judge)
+        description = "{} heuristic is done.".format(self.heuristic.name)
+        Event(action="done",
+              subject="allocate.py",
+              description=description)
 
     def assign_startups(self, judge):
         while judge.needs_another_startup():
@@ -62,7 +66,4 @@ class Allocator(object):
             judge.mark_as_done()
 
     def assess(self):
-        Event(action="done",
-              subject="allocate.py",
-              description="No more judges")
         self.heuristic.assess()

--- a/classes/assignments.py
+++ b/classes/assignments.py
@@ -3,8 +3,7 @@ assignments = {}
 
 def assign(judge, startup):
     if startup:
-        judge.startups.append(startup)
-        judge.remaining -= 1
+        judge.add_startup(startup)
         judge_assignments = assignments.get(judge.id(), set())
         judge_assignments.add(startup.id())
         assignments[judge.id()] = judge_assignments

--- a/classes/bin.py
+++ b/classes/bin.py
@@ -1,4 +1,5 @@
 from classes.assignments import has_been_assigned
+from classes.event import Event
 
 
 BIN_NO_WEIGHT = 0
@@ -16,11 +17,17 @@ class Bin(object):
         return "Generic Bin"
 
     def status(self):
+        action = "success"
+        object = ""
+        description = "Is empty"
         if self.queue:
-            print("fail,{bin},Queue has {count} applications,".format(
-                    bin=self, count=len(self.queue)))
-        else:
-            print("success,{bin},Is empty,".format(bin=self))
+            action = "fail"
+            object = self.queue[0]
+            description = "{} unread".format(len(self.queue))
+        Event(action=action,
+              subject=self,
+              object=object,
+              description=description)
 
     def add_startup(self, startup):
         result = self.match(startup)

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -43,6 +43,12 @@ class Entity(object):
         if value is not None:
             self.properties[property.name] = value
 
+    def add_fields_to_name(self, fields):
+        name = self.properties["name"]
+        for field in fields:
+            name += "-{value}".format(value=self.properties[field])
+        self.properties["name"] = name
+
 
 def csv_output(entities):
     print(CSV_HEADER)

--- a/classes/event.py
+++ b/classes/event.py
@@ -2,10 +2,18 @@ from collections import OrderedDict
 
 
 class Event(object):
+    all_events = []
+    ticks = 0
+
     def __init__(self, **kwargs):
-        self.fields = OrderedDict(
-            {"time": "", "action": "", "judge": "", "startup": "", "bin": ""})
+        self.fields = OrderedDict({"time": Event.ticks,
+                                   "action": "",
+                                   "subject": "",
+                                   "object": "",
+                                   "description": ""})
+        Event.ticks += 1
         self.fields.update(kwargs)
+        Event.all_events.append(self)
 
     def to_csv(self):
         template = (",".join(["{%s}" % key for key in self.fields.keys()]))

--- a/classes/event.py
+++ b/classes/event.py
@@ -6,11 +6,11 @@ class Event(object):
     ticks = 0
 
     def __init__(self, **kwargs):
-        self.fields = OrderedDict({"time": Event.ticks,
-                                   "action": "",
-                                   "subject": "",
-                                   "object": "",
-                                   "description": ""})
+        self.fields = OrderedDict([("time", Event.ticks),
+                                   ("action", ""),
+                                   ("subject", ""),
+                                   ("object", ""),
+                                   ("description", "")])
         Event.ticks += 1
         self.fields.update(kwargs)
         Event.all_events.append(self)

--- a/classes/feature_bins.py
+++ b/classes/feature_bins.py
@@ -21,6 +21,8 @@ INDUSTRY_WEIGHT = 2
 
 
 class FeatureBins(object):
+    name = "feature_bins"
+
     def __init__(self):
         self.bins = []
 

--- a/classes/feature_bins.py
+++ b/classes/feature_bins.py
@@ -1,4 +1,3 @@
-from classes.assignments import assign
 from classes.bin import (
     BIN_DEFAULT_WEIGHT,
     BIN_NO_WEIGHT,
@@ -62,21 +61,12 @@ class FeatureBins(object):
                         values=[value for value, _ in program.values],
                         weight=HOME_PROGRAM_WEIGHT*BIN_DEFAULT_WEIGHT))
 
-    def next_action(self, judge):
-        for event in judge.complete_startups():
+    def process_judge_events(self, events):
+        for event in events:
             for bin in self.bins:
-                bin.update(judge,
+                bin.update(event.fields["subject"],
                            event.fields["object"],
                            event.fields["action"] == "pass")
-        self.find_startups(judge)
-
-    def find_startups(self, judge):
-        while judge.needs_another_startup():
-            startup = self.find_one_startup(judge)
-            if not startup:
-                break
-        if not judge.startups:
-            judge.mark_as_done()
 
     def find_one_startup(self, judge):
         startup, best_bin = find_best_bin(self.bins, judge)
@@ -86,7 +76,6 @@ class FeatureBins(object):
                   object=judge,
                   description="{} left".format(len(best_bin.queue)))
             self.update_bins(startup, judge, True)
-            assign(judge, startup)
         return startup
 
     def assess(self):

--- a/classes/feature_bins.py
+++ b/classes/feature_bins.py
@@ -1,0 +1,68 @@
+from classes.bin import BIN_DEFAULT_WEIGHT
+from classes.female_bin import FemaleBin
+from classes.home_program_bin import HomeProgramBin
+from classes.industry_bin import IndustryBin
+from classes.property import program
+from classes.property import industry
+from classes.reads_bin import ReadsBin
+from classes.role_bin import RoleBin
+from classes.satisfied_bin import SatisfiedBin
+
+FEMALE_WEIGHT = 2
+ROLE_WEIGHT = 3
+HOME_PROGRAM_WEIGHT = 4
+JUDGE_ZSCORE_WEIGHT = 5
+INDUSTRY_WEIGHT = 2
+
+
+class FeatureBins(object):
+    def __init__(self):
+        self.bins = []
+
+    def setup(self, judges, startups):
+        self.default_bins()
+        self.add_startups(startups)
+        self.calc_capacity(judges)
+
+    def add_startups(self, startups):
+        for startup in startups:
+            for bin in self.bins:
+                bin.add_startup(startup)
+
+    def calc_capacity(self, judges):
+        for bin in self.bins:
+            bin.calc_capacity(judges)
+
+    def work_left(self):
+        return any([bin.work_left() for bin in self.bins])
+
+    def default_bins(self):
+        self.bins = (
+            [ReadsBin(),
+             SatisfiedBin(),
+             FemaleBin(weight=FEMALE_WEIGHT*BIN_DEFAULT_WEIGHT),
+             RoleBin(value="Executive",
+                     weight=ROLE_WEIGHT*BIN_DEFAULT_WEIGHT,
+                     count=2),
+             RoleBin(value="Lawyer",
+                     weight=ROLE_WEIGHT*BIN_DEFAULT_WEIGHT),
+             RoleBin(value="Investor",
+                     weight=ROLE_WEIGHT*BIN_DEFAULT_WEIGHT)] +
+            bin_factory(IndustryBin,
+                        values=[value for value, _ in industry.values],
+                        weight=INDUSTRY_WEIGHT*BIN_DEFAULT_WEIGHT) +
+            bin_factory(HomeProgramBin,
+                        values=[value for value, _ in program.values],
+                        weight=HOME_PROGRAM_WEIGHT*BIN_DEFAULT_WEIGHT))
+
+    def next_action(self, judge):
+        judge.next_action(self.bins)
+
+    def assess(self):
+        for bin in self.bins:
+            bin.status()
+
+
+def bin_factory(klass, values, weight):
+    return [klass(value=value, weight=weight)
+            for value in values]

--- a/classes/female_bin.py
+++ b/classes/female_bin.py
@@ -1,7 +1,4 @@
-from classes.bin import (
-    BIN_HIGH_WEIGHT,
-    Bin,
-)
+from classes.bin import Bin
 
 
 class FemaleBin(Bin):

--- a/classes/female_bin.py
+++ b/classes/female_bin.py
@@ -9,5 +9,5 @@ class FemaleBin(Bin):
         return "At Least One Female Read Bin"
 
     def weight(self, judge):
-        if judge.properties["gender"] == "female":
+        if judge.properties["gender"].startswith("f"):
             return super().weight(judge)

--- a/classes/heuristic.py
+++ b/classes/heuristic.py
@@ -1,5 +1,12 @@
 from classes.feature_bins import FeatureBins
+from classes.random_selection import RandomSelection
+
+HEURISTICS = [RandomSelection, FeatureBins]
 
 
 def find_heuristic(name):
-    return FeatureBins()
+    result = RandomSelection
+    options = [heuristic for heuristic in HEURISTICS if heuristic.name == name]
+    if options:
+        result = options[0]
+    return result()

--- a/classes/heuristic.py
+++ b/classes/heuristic.py
@@ -1,0 +1,5 @@
+from classes.feature_bins import FeatureBins
+
+
+def find_heuristic(name):
+    return FeatureBins()

--- a/classes/home_program_bin.py
+++ b/classes/home_program_bin.py
@@ -1,6 +1,5 @@
 from classes.bin import (
     BIN_DEFAULT_WEIGHT,
-    BIN_NO_WEIGHT,
     Bin,
 )
 
@@ -15,11 +14,5 @@ class HomeProgramBin(Bin):
     def __str__(self):
         return self.name_format.format(self.program)
 
-    def match(self, startup):
-        return startup.properties['program'] == self.program
-
-    def weight(self, judge):
-        if judge.properties['program'] == self.program:
-            return super().weight(judge)
-        else:
-            return BIN_NO_WEIGHT
+    def match(self, entity):
+        return entity.properties['program'] == self.program

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -14,83 +14,39 @@ class Judge(Entity):
     def __init__(self, data=None):
         super().__init__()
         self.startups = []
-        self.events = []
         self.type = "judge"
         for property in Property.all_properties:
             self.add_property(property, data)
+        self.add_fields_to_name(["industry", "program", "role", "gender"])
         self.remaining = int(self.properties.get("commitment", 50))
 
-    def next_action(self, bins):
+    def complete_startups(self):
+        events = []
         if self.startups:
-            return self.finish_startups(bins)
-        else:
-            return self.find_startups(bins)
-
-    def finish_startups(self, bins):
-        for startup in self.startups:
-            action = "finished"
-            keep = False
-            if self.passes(startup):
-                action = "pass"
-                keep = True
-            self.add_event(action=action, startup=startup)
-            for bin in bins:
-                bin.update(self, startup, keep)
-        self.startups = []
-        self.has_more_work = True
+            for startup in self.startups:
+                action = "finished"
+                if self.passes(startup):
+                    action = "pass"
+                events.append(Event(action=action,
+                                    subject=self,
+                                    object=startup))
+            self.startups = []
+            self.has_more_work = True
+        return events
 
     def passes(self, startup):
         return random() <= CHANCE_OF_PASS
 
-    def find_startups(self, bins):
-        while self.remaining > 0:
-            self.find_one_startup(bins)
-            if not self.has_more_work:
-                break
-        if not self.startups:
-            self.add_event("done")
-            self.remaining = 0
-        self.has_more_work = self.startups != []
+    def needs_another_startup(self):
+        return (self.remaining > 0 and
+                len(self.startups) < Judge.MAX_PANEL_SIZE)
 
-    def find_one_startup(self, bins):
-        if len(self.startups) < Judge.MAX_PANEL_SIZE:
-            startup = self.next_startup(bins)
-            if startup:
-                assign(self, startup)
-                self.has_more_work = True
-                return
-        self.has_more_work = False
-
-    def next_startup(self, bins):
-        best_bin = self.best_bin(bins)
-        if best_bin:
-            startup = best_bin.next_startup(self)
-            if startup:
-                startup.update(bins, True)
-                self.add_event("assigned", startup=startup, bin=best_bin)
-                self.has_more_work = True
-                return startup
-            else:
-                other_bins = [bin for bin in bins if bin != best_bin]
-                startup = self.next_startup(other_bins)
-                self.has_more_work = bool(startup)
-                return startup
-        return None
-
-    def best_bin(self, bins):
-        result = None
-        highest_weight = BIN_NO_WEIGHT
-        for bin in bins:
-            weight = bin.adjusted_weight(self)
-            if weight and weight > highest_weight:
-                highest_weight = weight
-                result = bin
+    def add_startup(self, startup):
+        self.startups.append(startup)
+        result = Event(action="assigned", subject=self, object=startup)
+        self.remaining -= 1
         return result
 
-    def add_event(self, action,
-                  startup="",
-                  bin=""):
-        self.events.append(Event(action=action,
-                                 judge=self,
-                                 startup=startup,
-                                 bin=bin))
+    def mark_as_done(self):
+        Event(action="done", subject=self)
+        self.remaining = 0

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -1,6 +1,4 @@
 from random import random
-from classes.assignments import assign
-from classes.bin import BIN_NO_WEIGHT
 from classes.entity import Entity
 from classes.property import Property
 from classes.event import Event

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -20,16 +20,14 @@ class Judge(Entity):
 
     def complete_startups(self):
         events = []
-        if self.startups:
-            for startup in self.startups:
-                action = "finished"
-                if self.passes(startup):
-                    action = "pass"
-                events.append(Event(action=action,
-                                    subject=self,
-                                    object=startup))
-            self.startups = []
-            self.has_more_work = True
+        for startup in self.startups:
+            action = "finished"
+            if self.passes(startup):
+                action = "pass"
+            events.append(Event(action=action,
+                                subject=self,
+                                object=startup))
+        self.startups = []
         return events
 
     def passes(self, startup):

--- a/classes/random_selection.py
+++ b/classes/random_selection.py
@@ -1,0 +1,21 @@
+from random import choice
+
+from classes.assignments import assign
+
+
+class RandomSelection(object):
+    name = "random"
+
+    def setup(self, judges, startups):
+        self.startups = startups
+
+    def work_left(self):
+        return True
+
+    def next_action(self, judge):
+        judge.complete_startups()
+        while judge.needs_another_startup():
+            assign(judge, choice(self.startups))
+
+    def assess(self):
+        pass

--- a/classes/random_selection.py
+++ b/classes/random_selection.py
@@ -1,7 +1,5 @@
 from random import choice
 
-from classes.assignments import assign
-
 
 class RandomSelection(object):
     name = "random"
@@ -12,10 +10,11 @@ class RandomSelection(object):
     def work_left(self):
         return True
 
-    def next_action(self, judge):
-        judge.complete_startups()
-        while judge.needs_another_startup():
-            assign(judge, choice(self.startups))
+    def process_judge_events(self, events):
+        pass
+
+    def find_one_startup(self, judge):
+        return choice(self.startups)
 
     def assess(self):
         pass

--- a/classes/startup.py
+++ b/classes/startup.py
@@ -13,7 +13,4 @@ class Startup(Entity):
         self.add_property(name, data)
         self.add_property(industry, data)
         self.add_property(program, data)
-
-    def update(self, bins, keep):
-        for bin in bins:
-            bin.update_startup(self, keep)
+        self.add_fields_to_name(["industry", "program"])

--- a/generate.py
+++ b/generate.py
@@ -4,8 +4,6 @@
 import sys
 from classes.entity import csv_output
 from classes.generator import Generator
-from classes.judge import Judge
-from classes.startup import Startup
 
 
 generator = Generator(judge_count=int(sys.argv[1]),


### PR DESCRIPTION
Work done:
- Abstracted FeatureBins heuristic out of the previous version of the code.
- Added RandomSelection heuristic.

To test:
- To run the FeatureBins heuristic run something like:
    `python3 allocate.py example.csv feature_bins > feature_bins.out`
- To run the RandomSelection heuristic run something like:
    `python3 allocate.py example.csv random > random.out`

The RandomSelection heuristic just gives random startups to each judge in turn.  The output combined with the input, `example.csv`, should have all the information needed for the analyzer and should suck.

THIS PR DOES NOT COMPLETE THE TICKET (but should be mergeable)