### PR TITLE
[AC-5504] Initial Allocation Analyzer

### DIFF
--- a/allocate.py
+++ b/allocate.py
@@ -25,7 +25,4 @@ allocator.read_entities()
 allocator.setup()
 allocator.allocate()
 
-
-for event in Event.all_events:
-    print (Event.headers())
-    print (event.to_csv())
+print (Event.all_events_as_csv())

--- a/allocate.py
+++ b/allocate.py
@@ -24,7 +24,8 @@ allocator = Allocator(filepath, heuristic)
 allocator.read_entities()
 allocator.setup()
 allocator.allocate()
-allocator.assess()
+
 
 for event in Event.all_events:
+    print (Event.headers())
     print (event.to_csv())

--- a/analyze.py
+++ b/analyze.py
@@ -15,7 +15,6 @@ else:
     allocation = "tmp.out"
 
 
-
 aa = quick_setup(scenario, allocation)
 for summary, word in [(aa.summarize(aa.analyze(aa.assigned)), "Assigned"),
                       (aa.summarize(aa.analyze(aa.completed)), "Completed")]:
@@ -25,4 +24,3 @@ for summary, word in [(aa.summarize(aa.analyze(aa.assigned)), "Assigned"),
 
 
 print()
-

--- a/analyze.py
+++ b/analyze.py
@@ -26,6 +26,5 @@ output.append("\n\nCompleted Application Stats\n------------------\n")
 output.extend("\n".join(["%s: %s" % (key, val) for key, val in completed_summary.items()]))
 
 stdout.writelines(output)
-
-
+print()
 

--- a/analyze.py
+++ b/analyze.py
@@ -17,14 +17,12 @@ else:
 
 
 aa = quick_setup(scenario, allocation)
-assigned_summary = aa.summarize(aa.analyze(aa.assigned))
-completed_summary = aa.summarize(aa.analyze(aa.completed))
+for summary, word in [(aa.summarize(aa.analyze(aa.assigned)), "Assigned"),
+                      (aa.summarize(aa.analyze(aa.completed)), "Completed")]:
+    print("\n%s Application Stats\n------------------\n" % word)
+    print("\n".join(["%s: %s" % (key, val)
+                     for key, val in summary.items()]))
 
-output = ["\nAssigned Application Stats\n------------------\n"]
-output.extend("\n".join(["%s: %s" % (key, val) for key, val in assigned_summary.items()]))
-output.append("\n\nCompleted Application Stats\n------------------\n")
-output.extend("\n".join(["%s: %s" % (key, val) for key, val in completed_summary.items()]))
 
-stdout.writelines(output)
 print()
 

--- a/analyze.py
+++ b/analyze.py
@@ -1,7 +1,22 @@
 from classes.allocation_analyzer import quick_setup
-from sys import stdout
+from sys import (
+    argv,
+    stdout,
+)
 
-aa = quick_setup()
+
+if len(argv) > 1:
+    scenario = argv[1]
+else:
+    scenario = "example.csv"
+if len(argv) > 2:
+    allocation = argv[2]
+else:
+    allocation = "tmp.out"
+
+
+
+aa = quick_setup(scenario, allocation)
 assigned_summary = aa.summarize(aa.analyze(aa.assigned))
 completed_summary = aa.summarize(aa.analyze(aa.completed))
 

--- a/analyze.py
+++ b/analyze.py
@@ -1,0 +1,16 @@
+from classes.allocation_analyzer import quick_setup
+from sys import stdout
+
+aa = quick_setup()
+assigned_summary = aa.summarize(aa.analyze(aa.assigned))
+completed_summary = aa.summarize(aa.analyze(aa.completed))
+
+output = ["\nAssigned Application Stats\n------------------\n"]
+output.extend("\n".join(["%s: %s" % (key, val) for key, val in assigned_summary.items()]))
+output.append("\n\nCompleted Application Stats\n------------------\n")
+output.extend("\n".join(["%s: %s" % (key, val) for key, val in completed_summary.items()]))
+
+stdout.writelines(output)
+
+
+

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -5,44 +5,13 @@ from collections import (
 )
 from classes.judge import Judge
 from classes.startup import Startup
+from classes.gender_distribution_metric import GenderDistributionMetric
+from classes.judge_role_distribution_metric import JudgeRoleDistributionMetric
+from classes.program_match_metric import ProgramMatchMetric
+from classes.industry_match_metric import IndustryMatchMetric
+from classes.total_reads_metric import TotalReadsMetric
+
 Assignment = namedtuple("Assignment", ["judge", "startup"])
-
-
-def increment_assignment_count(startup, metric_name, analysis):
-    name = startup['name']
-    analysis[name][metric_name] += 1
-
-
-def gender_distribution(assignment, read_counts):
-    judge, startup = assignment
-    metric_name = "%s_reads" % judge['gender']
-    increment_assignment_count(startup, metric_name, read_counts)
-
-
-def role_distribution(assignment, read_counts):
-    judge, startup = assignment
-    metric_name = "%s_reads" % judge['role']
-    increment_assignment_count(startup, metric_name, read_counts)
-
-
-def program_match(assignment, read_counts):
-    judge, startup = assignment
-    metric_name = "home_program_reads"
-    if startup['program'] == judge['program']:
-        increment_assignment_count(startup, metric_name, read_counts)
-
-
-def industry_match(assignment, read_counts):
-    judge, startup = assignment
-    metric_name = "matching_industry_reads"
-    if startup['industry'] == judge['industry']:
-        increment_assignment_count(startup, metric_name, read_counts)
-
-
-def total_reads(assignment, read_counts):
-    _, startup = assignment
-    increment_assignment_count(startup, 'total_reads', read_counts)
-
 
 class AllocationAnalyzer(object):
     def __init__(self):
@@ -50,11 +19,12 @@ class AllocationAnalyzer(object):
         self.startups = {}
         self.assigned = []
         self.completed = []
-        self.metrics = [total_reads,
-                        gender_distribution,
-                        role_distribution,
-                        program_match,
-                        industry_match]
+        self.metrics = [GenderDistributionMetric,
+                        JudgeRoleDistributionMetric,
+                        ProgramMatchMetric,
+                        IndustryMatchMetric,
+                        TotalReadsMetric,]
+                        
 
     def read_scenario_from_csv(self, input_file):
         with open(input_file) as file:
@@ -91,8 +61,8 @@ class AllocationAnalyzer(object):
         read_counts = {startup['name']: defaultdict(int)
                        for startup in self.startups.values()}
         for assignment in assignments:
-            for metric_fn in self.metrics:
-                metric_fn(assignment, read_counts)
+            for metric in self.metrics:
+                metric.evaluate(metric, assignment, read_counts)
 
         return read_counts
 

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -1,0 +1,249 @@
+from csv import DictReader
+from collections import (
+    defaultdict,
+    Counter,
+    OrderedDict,
+)
+from classes.judge import Judge
+from classes.startup import Startup
+
+class AllocationAnalyzer(object):
+    def __init__(self):
+        self.judges = {}
+        self.startups = {}
+
+    def read_scenario_from_csv(self, input_file):
+        with open(input_file) as file:
+            reader = DictReader(file)
+            self.process_scenario_from_csv(reader)
+        
+    def read_allocations_from_csv(self, input_file):
+        with open(input_file) as file:
+            reader = DictReader(file)            
+            self.process_allocations_from_csv(reader)
+
+    def read_preferences(self, input_file):
+        with open(input_file) as file:
+            preferences = file.readlines()
+        self.process_preferences
+
+    def process_scenario_from_csv(self, reader):
+        for row in reader:
+            if row['type'] == "judge":
+                judge = Judge(data=row)
+                self.judges[judge.properties['id']] = judge
+            elif row['type'] == "startup":
+                startup = Startup(data=row)
+                self.startups[startup.properties['id']] = startup
+            else:
+                print("Couldn't read row: %s" % ",".join(row))
+                
+    def process_allocations_from_csv(self, reader):
+        for row in reader:
+            
+                
+#     def calc_all_stats(self):
+#         self.calc_completed_read_counts()
+#         self.calc_industry_distributions()
+#         self.calc_home_program_data()
+#         self.calc_gender_distributions()
+#         self.calc_expert_category_distribution()
+
+#     def calc_expert_category_distribution(self):
+
+#         read_by_category = defaultdict(int)
+#         read_by_more_than_one_of_category = defaultdict(int)
+#         not_read_by_category = defaultdict(int)
+
+#         categories = ExpertCategory.objects.all()
+#         for app in self.apps:
+#             for category in categories:
+#                 cat_count = self.jafs.filter(
+#                     application=app,
+#                     feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
+#                     judge__expertprofile__expert_category=category).count()
+#                 self.app_stats[app.id][category.name] = cat_count
+#                 if cat_count > 0:
+#                     read_by_category[category.name] += 1
+#                 if cat_count > 1:
+#                     read_by_more_than_one_of_category[category.name] += 1
+
+#                 if cat_count == 0:
+#                     not_read_by_category[category.name] += 1
+#         self.stats.update({"Applications read by %ss" % cat.name: read_by_category[cat.name]
+#                            for cat in categories})
+#         self.stats.update({"Applications read by more than one %ss" % cat.name: read_by_more_than_one_of_category[cat.name]
+#                            for cat in categories})
+
+#         self.stats.update({"Applications not read by %ss" % cat.name: not_read_by_category[cat.name]
+#                            for cat in categories})
+#         for category in categories:
+#             self.stats['Total reads by %ss' % category.name] = self.jafs.filter(
+#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
+#                 judge__expertprofile__expert_category=category).count()
+
+#     def calc_completed_read_counts(self):
+#         completed_reads = self.jafs.filter(
+#             feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE)
+#         self.read_counter = Counter([jaf.application_id for jaf in completed_reads])
+
+#         for app_id, read_count in self.read_counter.items():
+#             self.app_stats[app_id]['completed_reads'] = read_count
+#         self.stats['Total completed reads'] = completed_reads.count()
+#         self.stats['Average number of completed reads'] = (
+#             float(completed_reads.count())/self.apps.count())
+#         self.read_count_distribution = Counter(self.read_counter.values())
+
+#     def calc_industry_distributions(self):
+#         expert_industries = dict(ExpertProfile.objects.filter(
+#             user__judgeapplicationfeedback__in=self.jafs).distinct().values_list(
+#                 'id', 'primary_industry'))
+#         top_level_industries = dict(Industry.objects.all().values_list(
+#             'pk', 'parent_id'))
+#         for pk, parent_id in top_level_industries.items():
+#             if parent_id is None:
+#                 top_level_industries[pk]=pk
+
+#         apps_with_primary_industry_reader = []
+#         apps_missing_primary_industry_reader = defaultdict(int)
+#         apps_with_knowledgeable_reader = []
+#         apps_without_knowledgeable_reader = []
+
+#         for app in self.apps:
+#             industry = parent_industry(app.startup.primary_industry)
+#             app_expert_ids = self.jafs.filter(
+#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
+#                 application=app).values_list('judge__expertprofile__id',
+#                                              flat=True)
+#             app_expert_industries = [top_level_industries[expert_industries[id]]
+#                                      for id in app_expert_ids]
+#             if industry.pk in app_expert_industries:
+#                 apps_with_primary_industry_reader.append(app)
+#                 apps_with_knowledgeable_reader.append(app)
+#             else:
+#                 apps_missing_primary_industry_reader['total'] += 1
+#                 apps_missing_primary_industry_reader[industry.name] += 1
+#                 app_sibling_industries = [val for key, val in top_level_industries.items()
+#                                           if key == industry.pk]
+#                 if self.jafs.filter(
+#                         feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
+#                         judge__expertprofile__additional_industries__in=app_sibling_industries,
+#                         application=app).exists():
+#                     apps_with_knowledgeable_reader.append(app)
+#                 else:
+#                     apps_without_knowledgeable_reader.append(app)
+#         self.stats['Primary industry reader requirement satisfied'] = len(
+#             apps_with_primary_industry_reader)
+#         self.stats.update(
+#             {'Primary industry reader requirement unsatisfied: %s' % industry :app_count
+#              for industry, app_count in apps_missing_primary_industry_reader.items()})
+
+#         self.stats['Apps with at least one knowledgeable reader'] = len(
+#             apps_with_knowledgeable_reader)
+#         self.stats['Apps without at least one knowledgeable reader'] = len(
+#             apps_without_knowledgeable_reader)
+#         for industry in Industry.objects.filter(parent__isnull=True):
+#             self.stats['Total completed reads for %s' % industry.name] = self.jafs.filter(
+#                 judge__expertprofile__primary_industry=industry,
+#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE).count()
+#             industry_startups = (
+#                 self.apps.filter(startup__primary_industry=industry).count() +
+#                 self.apps.filter(startup__primary_industry__parent=industry).count())
+
+#             self.stats['Total startups with primary industry %s' % industry.name] = industry_startups
+
+#     def calc_gender_distributions(self):
+#         total_female_reads = 0
+#         for app in self.apps:
+#             female_reads = self.jafs.filter(
+#                 application=app,
+#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
+#                 judge__expertprofile__gender='f').count()
+#             self.app_stats[app.id]['female_reads'] = female_reads
+#             total_female_reads += female_reads
+#         self.stats['Total reads by female judges'] = total_female_reads
+#         self.stats['Average reads by female judges'] = float(total_female_reads)/self.apps.count()
+
+#         no_female_reads = sum([1 for row in self.app_stats.values() if row['female_reads']==0])
+#         one_female_read = sum([1 for row in self.app_stats.values() if row['female_reads']==1])
+#         multi_female_reads = sum([1 for row in self.app_stats.values() if row['female_reads']>1])
+#         self.stats['Number of applications with no female judge reads'] = no_female_reads
+#         self.stats['Number of applications with exactly one female judge read'] = one_female_read
+#         self.stats['Number of applications with >1 female judge reads'] = multi_female_reads
+
+
+#     def calc_home_program_data(self):
+#         preferred_programs = {}
+#         program_counts = {}
+#         cycle = self.judging_round.program.cycle
+#         for app in self.apps:
+#             spi = app.startup.startupprograminterest_set.filter(
+#                 applying=True, program__cycle=cycle).order_by('order').first()
+#             if spi:
+
+#                 preferred_programs[app.id] = spi.program
+#                 program_counts[spi.program] = 1 + program_counts.get(spi.program, 0)
+#             else:
+#                 # how did this happen?
+#                 pass
+                
+#         hits = 0
+#         misses = 0
+#         program_misses = {}
+#         for app in self.apps:
+#             if app.id  in preferred_programs:
+#                 program = preferred_programs[app.id]
+#                 judges = self.jafs.filter(
+#                     feedback_status="COMPLETE",
+#                     application=app,
+#                     judge__expertprofile__home_program_family=program.program_family)
+#                 if judges.count() == 0:
+#                     program_misses[program] = 1 + program_misses.get(program, 0)
+#                     misses += 1
+#                 else:
+#                     hits += 1
+#         self.stats['Apps judged by at least one judge from their home program'] = hits
+#         self.stats['Apps not judged by any judge from their home program'] = misses
+#         for program in program_misses.keys():
+#             self.stats['%s apps not judged by any judge from that program' % program.name] = program_misses[program]
+            
+#             total_program_reads = self.jafs.filter(
+#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
+#                 judge__expertprofile__home_program_family=program.program_family)
+#             self.stats['Total apps for %s' % program.name] = program_counts[program]
+#             self.stats['Total reads for %s' % program.name] = total_program_reads.count()
+
+
+#     def calc_judge_bias_distribution(self):
+#         pass
+#         # judge_z_scores = {row['Judge ID']: row['Z-score'] for row in self.pivot_table.rows}
+#         # app_z_scores = defaultdict(list)
+#         # for app_id, judge_id in self.jafs.filter(
+#         #         feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE
+#         # ).values_list("application_id", "judge_id"):
+#         #     app_z_scores[app_id].append(judge_z_scores[judge_id])
+#         # for app_id, scores in app_z_scores.items():
+#         #     self.app_stats[app_id]['average_z_score'] = mean(scores)
+#         # average_of_z_scores = [row['average_z_score'] for row in self.app_stats.values()]
+#         # self.stats['Average average z-score'] = mean(average_of_z_scores)
+#         # self.stats['Max average z-score'] = max(average_of_z_scores)
+#         # self.stats['Min average z-score'] = min(average_of_z_scores)
+#         # self.stats['Number of apps with positive average z-score'] = len(
+#         #     [score for score in average_of_z_scores if score > 0])
+#         # self.stats['Number of apps with negative average z-score'] = len(
+#         #     [score for score in average_of_z_scores if score < 0])
+#         # self.stats['Number of apps with average z-score > .5'] = len(
+#         #     [score for score in average_of_z_scores if score > .5])
+#         # self.stats['Number of apps with average z-score < -.5'] = len(
+#         #     [score for score in average_of_z_scores if score < -.5])
+
+#         # self.stats['Max judge z-score for this round'] = max(judge_z_scores.values())
+#         # self.stats['Min judge z-score for this round'] = min(judge_z_scores.values())
+
+
+
+# def parent_industry(industry):
+#     return industry.parent or industry
+
+# def mean(collection):
+#     return float(sum(collection)) / len(collection)

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -11,7 +11,7 @@ Assignment = namedtuple("Assignment", ["judge", "startup"])
 
 
 def increment_assignment_count(startup, metric_name, analysis):
-    name = startup.properties['name']
+    name = startup['name']
     analysis[name][metric_name] += 1
 
     
@@ -22,7 +22,7 @@ def female_judge(assignment, analysis):
 
 def role_distribution(assignment, analysis):
     judge, startup = assignment
-    metric_name = "%s_reads" % judge.properties['role']
+    metric_name = "%s_reads" % judge['role']
     increment_assignment_count(startup, metric_name, analysis)
 
 def program_match(assignment, analysis):
@@ -39,7 +39,9 @@ def industry_match(assignment, analysis):
         increment_assignment_count(startup, metric_name, analysis)
 
 
-    
+def total_reads(assignment, analysis):
+    _, startup = assignment
+    increment_assignment_count(startup, 'total_reads', analysis)
     
 class AllocationAnalyzer(object):
     def __init__(self):
@@ -47,7 +49,8 @@ class AllocationAnalyzer(object):
         self.startups = {}
         self.assigned = []
         self.completed = []
-        self.metrics = [female_judge,
+        self.metrics = [total_reads,
+                        female_judge,
                         role_distribution,
                         program_match,
                         industry_match]
@@ -66,10 +69,10 @@ class AllocationAnalyzer(object):
         for row in reader:
             if row['type'] == "judge":
                 judge = Judge(data=row)
-                self.judges[judge.properties['name']] = judge
+                self.judges[judge['name']] = judge
             elif row['type'] == "startup":
                 startup = Startup(data=row)
-                self.startups[startup.properties['name']] = startup
+                self.startups[startup['name']] = startup
             else:
                 print("Couldn't read row: %s" % ",".join(row))
                 
@@ -85,11 +88,12 @@ class AllocationAnalyzer(object):
     
                                
     def analyze(self, assignments):
-        analysis = {startup.properties['name']: defaultdict(int)
+        analysis = {startup['name']: defaultdict(int)
                     for startup in self.startups.values()}
         for assignment in assignments:
             for metric_fn in self.metrics:
                 metric_fn(assignment, analysis)
+
         return analysis
         
             

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -12,6 +12,7 @@ from classes.industry_match_metric import IndustryMatchMetric
 from classes.total_reads_metric import TotalReadsMetric
 
 Assignment = namedtuple("Assignment", ["judge", "startup"])
+TOTAL_READS_TARGET = 5
 
 class AllocationAnalyzer(object):
     def __init__(self):
@@ -19,9 +20,9 @@ class AllocationAnalyzer(object):
         self.startups = {}
         self.assigned = []
         self.completed = []
-        self.metrics = [ProgramMatchMetric(),
-                        IndustryMatchMetric(),
-                        TotalReadsMetric(),]
+        self.metrics = [ProgramMatchMetric(1),
+                        IndustryMatchMetric(1),
+                        TotalReadsMetric(TOTAL_READS_TARGET),]
         self.metrics.extend([
             JudgeRoleDistributionMetric('Lawyer', 1),
             JudgeRoleDistributionMetric('Executive', 2),
@@ -77,17 +78,17 @@ class AllocationAnalyzer(object):
         summary = defaultdict(int)
         maxes = defaultdict(int)
         misses = defaultdict(list)
-        for app, count_dict in read_counts.items():
-            for metric, count in count_dict.items():
-                summary[metric] += count
-                maxes[metric] = max(maxes[metric], count)
         total_applications = len(self.startups)
         total_judges = len(self.judges)
         for metric, count in list(summary.items()):
             summary['average %s' % metric] = count / total_applications
         for metric, val in list(maxes.items()):
             summary['max %s' % metric] = val
-
+        for metric in self.metrics:
+            summary['total %s' % metric.output_key()] = metric.total 
+            summary['max %s'  % metric.output_key()] = metric.max_count
+            summary['missed %s' % metric.output_key()] = len(metric.unsatisfied_apps)
+            
         summary['total_applications'] = total_applications
         summary['total_judges'] = total_judges
         return summary

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -14,6 +14,7 @@ from classes.total_reads_metric import TotalReadsMetric
 Assignment = namedtuple("Assignment", ["judge", "startup"])
 TOTAL_READS_TARGET = 5
 
+
 class AllocationAnalyzer(object):
     def __init__(self):
         self.judges = {}
@@ -22,7 +23,7 @@ class AllocationAnalyzer(object):
         self.completed = []
         self.metrics = [ProgramMatchMetric(1),
                         IndustryMatchMetric(1),
-                        TotalReadsMetric(TOTAL_READS_TARGET),]
+                        TotalReadsMetric(TOTAL_READS_TARGET)]
         self.metrics.extend([
             JudgeRoleDistributionMetric('Lawyer', 1),
             JudgeRoleDistributionMetric('Executive', 2),
@@ -45,7 +46,7 @@ class AllocationAnalyzer(object):
                 print("Couldn't read row: %s" % ",".join(row))
 
     def process_allocations_from_csv(self, input_file):
-        reader = open_csv_reader(input_file)        
+        reader = open_csv_reader(input_file)
         for row in reader:
             judge = self.judges.get(row['subject'])
             startup = self.startups.get(row['object'])
@@ -76,8 +77,9 @@ class AllocationAnalyzer(object):
             summary['max %s' % metric] = val
         for metric in self.metrics:
             summary['total %s' % metric.output_key()] = metric.total
-            summary['max %s'  % metric.output_key()] = metric.max_count
-            summary['missed %s' % metric.output_key()] = len(metric.unsatisfied_apps)
+            summary['max %s' % metric.output_key()] = metric.max_count
+            missed_count = len(metric.unsatisfied_apps)
+            summary['missed %s' % metric.output_key()] = missed_count
 
         summary['total_applications'] = total_applications
         summary['total_judges'] = total_judges

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -31,20 +31,9 @@ class AllocationAnalyzer(object):
         self.metrics.extend([
             GenderDistributionMetric('male', 0),
             GenderDistributionMetric('female', 1)])
-                            
-                        
 
-    def read_scenario_from_csv(self, input_file):
-        with open(input_file) as file:
-            reader = DictReader(file)
-            self.process_scenario_from_csv(reader)
-
-    def read_allocations_from_csv(self, input_file):
-        with open(input_file) as file:
-            reader = DictReader(file)
-            self.process_allocations_from_csv(reader)
-
-    def process_scenario_from_csv(self, reader):
+    def process_scenario_from_csv(self, input_file):
+        reader = open_csv_reader(input_file)
         for row in reader:
             if row['type'] == "judge":
                 judge = Judge(data=row)
@@ -55,7 +44,8 @@ class AllocationAnalyzer(object):
             else:
                 print("Couldn't read row: %s" % ",".join(row))
 
-    def process_allocations_from_csv(self, reader):
+    def process_allocations_from_csv(self, input_file):
+        reader = open_csv_reader(input_file)        
         for row in reader:
             judge = self.judges.get(row['subject'])
             startup = self.startups.get(row['object'])
@@ -85,10 +75,10 @@ class AllocationAnalyzer(object):
         for metric, val in list(maxes.items()):
             summary['max %s' % metric] = val
         for metric in self.metrics:
-            summary['total %s' % metric.output_key()] = metric.total 
+            summary['total %s' % metric.output_key()] = metric.total
             summary['max %s'  % metric.output_key()] = metric.max_count
             summary['missed %s' % metric.output_key()] = len(metric.unsatisfied_apps)
-            
+
         summary['total_applications'] = total_applications
         summary['total_judges'] = total_judges
         return summary
@@ -96,6 +86,12 @@ class AllocationAnalyzer(object):
 
 def quick_setup(scenario='example.csv', allocation='tmp.out'):
     aa = AllocationAnalyzer()
-    aa.read_scenario_from_csv(scenario)
-    aa.read_allocations_from_csv(allocation)
+    aa.process_scenario_from_csv(scenario)
+    aa.process_allocations_from_csv(allocation)
     return aa
+
+
+def open_csv_reader(input_file):
+    file = open(input_file)
+    reader = DictReader(file)
+    return reader

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -15,33 +15,33 @@ def increment_assignment_count(startup, metric_name, analysis):
     analysis[name][metric_name] += 1
 
     
-def female_judge(assignment, analysis):
+def female_judge(assignment, read_counts):
     judge, startup = assignment
     if judge.is_female():
-        increment_assignment_count(startup, 'female_reads', analysis)
+        increment_assignment_count(startup, 'female_reads', read_counts)
 
-def role_distribution(assignment, analysis):
+def role_distribution(assignment, read_counts):
     judge, startup = assignment
     metric_name = "%s_reads" % judge['role']
-    increment_assignment_count(startup, metric_name, analysis)
+    increment_assignment_count(startup, metric_name, read_counts)
 
-def program_match(assignment, analysis):
+def program_match(assignment, read_counts):
     judge, startup = assignment
     metric_name = "home_program_reads"
     if startup['program'] == judge['program']:
-        increment_assignment_count(startup, metric_name, analysis)
+        increment_assignment_count(startup, metric_name, read_counts)
 
 
-def industry_match(assignment, analysis):
+def industry_match(assignment, read_counts):
     judge, startup = assignment
     metric_name = "matching_industry_reads"
     if startup['industry'] == judge['industry']:
-        increment_assignment_count(startup, metric_name, analysis)
+        increment_assignment_count(startup, metric_name, read_counts)
 
 
-def total_reads(assignment, analysis):
+def total_reads(assignment, read_counts):
     _, startup = assignment
-    increment_assignment_count(startup, 'total_reads', analysis)
+    increment_assignment_count(startup, 'total_reads', read_counts)
     
 class AllocationAnalyzer(object):
     def __init__(self):
@@ -88,221 +88,13 @@ class AllocationAnalyzer(object):
     
                                
     def analyze(self, assignments):
-        analysis = {startup['name']: defaultdict(int)
+        read_counts = {startup['name']: defaultdict(int)
                     for startup in self.startups.values()}
         for assignment in assignments:
             for metric_fn in self.metrics:
-                metric_fn(assignment, analysis)
-
-        return analysis
+                metric_fn(assignment, read_counts)
         
-            
-                
-#     def calc_all_stats(self):
-#         self.calc_completed_read_counts()
-#         self.calc_industry_distributions()
-#         self.calc_home_program_data()
-#         self.calc_gender_distributions()
-#         self.calc_expert_category_distribution()
-
-#     def calc_expert_category_distribution(self):
-
-#         read_by_category = defaultdict(int)
-#         read_by_more_than_one_of_category = defaultdict(int)
-#         not_read_by_category = defaultdict(int)
-
-#         categories = ExpertCategory.objects.all()
-#         for app in self.apps:
-#             for category in categories:
-#                 cat_count = self.jafs.filter(
-#                     application=app,
-#                     feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
-#                     judge__expertprofile__expert_category=category).count()
-#                 self.app_stats[app.id][category.name] = cat_count
-#                 if cat_count > 0:
-#                     read_by_category[category.name] += 1
-#                 if cat_count > 1:
-#                     read_by_more_than_one_of_category[category.name] += 1
-
-#                 if cat_count == 0:
-#                     not_read_by_category[category.name] += 1
-#         self.stats.update({"Applications read by %ss" % cat.name: read_by_category[cat.name]
-#                            for cat in categories})
-#         self.stats.update({"Applications read by more than one %ss" % cat.name: read_by_more_than_one_of_category[cat.name]
-#                            for cat in categories})
-
-#         self.stats.update({"Applications not read by %ss" % cat.name: not_read_by_category[cat.name]
-#                            for cat in categories})
-#         for category in categories:
-#             self.stats['Total reads by %ss' % category.name] = self.jafs.filter(
-#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
-#                 judge__expertprofile__expert_category=category).count()
-
-#     def calc_completed_read_counts(self):
-#         completed_reads = self.jafs.filter(
-#             feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE)
-#         self.read_counter = Counter([jaf.application_id for jaf in completed_reads])
-
-#         for app_id, read_count in self.read_counter.items():
-#             self.app_stats[app_id]['completed_reads'] = read_count
-#         self.stats['Total completed reads'] = completed_reads.count()
-#         self.stats['Average number of completed reads'] = (
-#             float(completed_reads.count())/self.apps.count())
-#         self.read_count_distribution = Counter(self.read_counter.values())
-
-#     def calc_industry_distributions(self):
-#         expert_industries = dict(ExpertProfile.objects.filter(
-#             user__judgeapplicationfeedback__in=self.jafs).distinct().values_list(
-#                 'id', 'primary_industry'))
-#         top_level_industries = dict(Industry.objects.all().values_list(
-#             'pk', 'parent_id'))
-#         for pk, parent_id in top_level_industries.items():
-#             if parent_id is None:
-#                 top_level_industries[pk]=pk
-
-#         apps_with_primary_industry_reader = []
-#         apps_missing_primary_industry_reader = defaultdict(int)
-#         apps_with_knowledgeable_reader = []
-#         apps_without_knowledgeable_reader = []
-
-#         for app in self.apps:
-#             industry = parent_industry(app.startup.primary_industry)
-#             app_expert_ids = self.jafs.filter(
-#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
-#                 application=app).values_list('judge__expertprofile__id',
-#                                              flat=True)
-#             app_expert_industries = [top_level_industries[expert_industries[id]]
-#                                      for id in app_expert_ids]
-#             if industry.pk in app_expert_industries:
-#                 apps_with_primary_industry_reader.append(app)
-#                 apps_with_knowledgeable_reader.append(app)
-#             else:
-#                 apps_missing_primary_industry_reader['total'] += 1
-#                 apps_missing_primary_industry_reader[industry.name] += 1
-#                 app_sibling_industries = [val for key, val in top_level_industries.items()
-#                                           if key == industry.pk]
-#                 if self.jafs.filter(
-#                         feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
-#                         judge__expertprofile__additional_industries__in=app_sibling_industries,
-#                         application=app).exists():
-#                     apps_with_knowledgeable_reader.append(app)
-#                 else:
-#                     apps_without_knowledgeable_reader.append(app)
-#         self.stats['Primary industry reader requirement satisfied'] = len(
-#             apps_with_primary_industry_reader)
-#         self.stats.update(
-#             {'Primary industry reader requirement unsatisfied: %s' % industry :app_count
-#              for industry, app_count in apps_missing_primary_industry_reader.items()})
-
-#         self.stats['Apps with at least one knowledgeable reader'] = len(
-#             apps_with_knowledgeable_reader)
-#         self.stats['Apps without at least one knowledgeable reader'] = len(
-#             apps_without_knowledgeable_reader)
-#         for industry in Industry.objects.filter(parent__isnull=True):
-#             self.stats['Total completed reads for %s' % industry.name] = self.jafs.filter(
-#                 judge__expertprofile__primary_industry=industry,
-#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE).count()
-#             industry_startups = (
-#                 self.apps.filter(startup__primary_industry=industry).count() +
-#                 self.apps.filter(startup__primary_industry__parent=industry).count())
-
-#             self.stats['Total startups with primary industry %s' % industry.name] = industry_startups
-
-#     def calc_gender_distributions(self):
-#         total_female_reads = 0
-#         for app in self.apps:
-#             female_reads = self.jafs.filter(
-#                 application=app,
-#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
-#                 judge__expertprofile__gender='f').count()
-#             self.app_stats[app.id]['female_reads'] = female_reads
-#             total_female_reads += female_reads
-#         self.stats['Total reads by female judges'] = total_female_reads
-#         self.stats['Average reads by female judges'] = float(total_female_reads)/self.apps.count()
-
-#         no_female_reads = sum([1 for row in self.app_stats.values() if row['female_reads']==0])
-#         one_female_read = sum([1 for row in self.app_stats.values() if row['female_reads']==1])
-#         multi_female_reads = sum([1 for row in self.app_stats.values() if row['female_reads']>1])
-#         self.stats['Number of applications with no female judge reads'] = no_female_reads
-#         self.stats['Number of applications with exactly one female judge read'] = one_female_read
-#         self.stats['Number of applications with >1 female judge reads'] = multi_female_reads
-
-
-#     def calc_home_program_data(self):
-#         preferred_programs = {}
-#         program_counts = {}
-#         cycle = self.judging_round.program.cycle
-#         for app in self.apps:
-#             spi = app.startup.startupprograminterest_set.filter(
-#                 applying=True, program__cycle=cycle).order_by('order').first()
-#             if spi:
-
-#                 preferred_programs[app.id] = spi.program
-#                 program_counts[spi.program] = 1 + program_counts.get(spi.program, 0)
-#             else:
-#                 # how did this happen?
-#                 pass
-                
-#         hits = 0
-#         misses = 0
-#         program_misses = {}
-#         for app in self.apps:
-#             if app.id  in preferred_programs:
-#                 program = preferred_programs[app.id]
-#                 judges = self.jafs.filter(
-#                     feedback_status="COMPLETE",
-#                     application=app,
-#                     judge__expertprofile__home_program_family=program.program_family)
-#                 if judges.count() == 0:
-#                     program_misses[program] = 1 + program_misses.get(program, 0)
-#                     misses += 1
-#                 else:
-#                     hits += 1
-#         self.stats['Apps judged by at least one judge from their home program'] = hits
-#         self.stats['Apps not judged by any judge from their home program'] = misses
-#         for program in program_misses.keys():
-#             self.stats['%s apps not judged by any judge from that program' % program.name] = program_misses[program]
-            
-#             total_program_reads = self.jafs.filter(
-#                 feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE,
-#                 judge__expertprofile__home_program_family=program.program_family)
-#             self.stats['Total apps for %s' % program.name] = program_counts[program]
-#             self.stats['Total reads for %s' % program.name] = total_program_reads.count()
-
-
-#     def calc_judge_bias_distribution(self):
-#         pass
-#         # judge_z_scores = {row['Judge ID']: row['Z-score'] for row in self.pivot_table.rows}
-#         # app_z_scores = defaultdict(list)
-#         # for app_id, judge_id in self.jafs.filter(
-#         #         feedback_status=JUDGING_FEEDBACK_STATUS_COMPLETE
-#         # ).values_list("application_id", "judge_id"):
-#         #     app_z_scores[app_id].append(judge_z_scores[judge_id])
-#         # for app_id, scores in app_z_scores.items():
-#         #     self.app_stats[app_id]['average_z_score'] = mean(scores)
-#         # average_of_z_scores = [row['average_z_score'] for row in self.app_stats.values()]
-#         # self.stats['Average average z-score'] = mean(average_of_z_scores)
-#         # self.stats['Max average z-score'] = max(average_of_z_scores)
-#         # self.stats['Min average z-score'] = min(average_of_z_scores)
-#         # self.stats['Number of apps with positive average z-score'] = len(
-#         #     [score for score in average_of_z_scores if score > 0])
-#         # self.stats['Number of apps with negative average z-score'] = len(
-#         #     [score for score in average_of_z_scores if score < 0])
-#         # self.stats['Number of apps with average z-score > .5'] = len(
-#         #     [score for score in average_of_z_scores if score > .5])
-#         # self.stats['Number of apps with average z-score < -.5'] = len(
-#         #     [score for score in average_of_z_scores if score < -.5])
-
-#         # self.stats['Max judge z-score for this round'] = max(judge_z_scores.values())
-#         # self.stats['Min judge z-score for this round'] = min(judge_z_scores.values())
-
-
-
-# def parent_industry(industry):
-#     return industry.parent or industry
-
-# def mean(collection):
-#     return float(sum(collection)) / len(collection)
+        return read_counts
 
 
 def quick_setup():

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -19,11 +19,18 @@ class AllocationAnalyzer(object):
         self.startups = {}
         self.assigned = []
         self.completed = []
-        self.metrics = [GenderDistributionMetric,
-                        JudgeRoleDistributionMetric,
-                        ProgramMatchMetric,
-                        IndustryMatchMetric,
-                        TotalReadsMetric,]
+        self.metrics = [ProgramMatchMetric(),
+                        IndustryMatchMetric(),
+                        TotalReadsMetric(),]
+        self.metrics.extend([
+            JudgeRoleDistributionMetric('Lawyer', 1),
+            JudgeRoleDistributionMetric('Executive', 2),
+            JudgeRoleDistributionMetric('Investor', 1),
+            JudgeRoleDistributionMetric('Other', 0)])
+        self.metrics.extend([
+            GenderDistributionMetric('male', 0),
+            GenderDistributionMetric('female', 1)])
+                            
                         
 
     def read_scenario_from_csv(self, input_file):
@@ -62,27 +69,24 @@ class AllocationAnalyzer(object):
                        for startup in self.startups.values()}
         for assignment in assignments:
             for metric in self.metrics:
-                metric.evaluate(metric, assignment, read_counts)
+                metric.evaluate(assignment, read_counts)
 
         return read_counts
 
     def summarize(self, read_counts):
         summary = defaultdict(int)
         maxes = defaultdict(int)
-        mins = defaultdict(int)
+        misses = defaultdict(list)
         for app, count_dict in read_counts.items():
             for metric, count in count_dict.items():
                 summary[metric] += count
                 maxes[metric] = max(maxes[metric], count)
-                mins[metric] = max(mins[metric], -count)
         total_applications = len(self.startups)
         total_judges = len(self.judges)
         for metric, count in list(summary.items()):
             summary['average %s' % metric] = count / total_applications
         for metric, val in list(maxes.items()):
             summary['max %s' % metric] = val
-        for metric, val in list(mins.items()):
-            summary['min %s' % metric] = -val
 
         summary['total_applications'] = total_applications
         summary['total_judges'] = total_judges

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -13,10 +13,10 @@ def increment_assignment_count(startup, metric_name, analysis):
     analysis[name][metric_name] += 1
 
 
-def female_judge(assignment, read_counts):
+def gender_distribution(assignment, read_counts):
     judge, startup = assignment
-    if judge.is_female():
-        increment_assignment_count(startup, 'female_reads', read_counts)
+    metric_name = "%s_reads" % judge['gender']
+    increment_assignment_count(startup, metric_name, read_counts)
 
 
 def role_distribution(assignment, read_counts):
@@ -51,7 +51,7 @@ class AllocationAnalyzer(object):
         self.assigned = []
         self.completed = []
         self.metrics = [total_reads,
-                        female_judge,
+                        gender_distribution,
                         role_distribution,
                         program_match,
                         industry_match]
@@ -119,8 +119,8 @@ class AllocationAnalyzer(object):
         return summary
 
 
-def quick_setup():
+def quick_setup(scenario='example.csv', allocation='tmp.out'):
     aa = AllocationAnalyzer()
-    aa.read_scenario_from_csv('example.csv')
-    aa.read_allocations_from_csv('tmp.out')
+    aa.read_scenario_from_csv(scenario)
+    aa.read_allocations_from_csv(allocation)
     return aa

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -96,6 +96,27 @@ class AllocationAnalyzer(object):
         
         return read_counts
 
+    def summarize(self, read_counts):
+        summary = defaultdict(int)
+        maxes = defaultdict(int)
+        mins = defaultdict(int)
+        for app, count_dict in read_counts.items():
+            for metric, count in count_dict.items():
+                summary[metric] += count
+                maxes[metric] = max(maxes[metric], count)
+                mins[metric] = max(mins[metric], -count)
+        total_applications = len(self.startups)
+        total_judges = len(self.judges)
+        for metric, count in list(summary.items()):
+            summary['average %s' % metric] = count / total_applications
+        for metric, val in list(maxes.items()):
+            summary['max %s' % metric] = val
+        for metric, val in list(mins.items()):
+            summary['min %s' % metric] = -val
+        
+        summary['total_applications'] = total_applications        
+        summary['total_judges'] = total_judges
+        return summary
 
 def quick_setup():
     aa = AllocationAnalyzer()

--- a/classes/allocation_analyzer.py
+++ b/classes/allocation_analyzer.py
@@ -1,9 +1,7 @@
 from csv import DictReader
 from collections import (
     defaultdict,
-    Counter,
     namedtuple,
-    OrderedDict,
 )
 from classes.judge import Judge
 from classes.startup import Startup
@@ -14,16 +12,18 @@ def increment_assignment_count(startup, metric_name, analysis):
     name = startup['name']
     analysis[name][metric_name] += 1
 
-    
+
 def female_judge(assignment, read_counts):
     judge, startup = assignment
     if judge.is_female():
         increment_assignment_count(startup, 'female_reads', read_counts)
 
+
 def role_distribution(assignment, read_counts):
     judge, startup = assignment
     metric_name = "%s_reads" % judge['role']
     increment_assignment_count(startup, metric_name, read_counts)
+
 
 def program_match(assignment, read_counts):
     judge, startup = assignment
@@ -42,7 +42,8 @@ def industry_match(assignment, read_counts):
 def total_reads(assignment, read_counts):
     _, startup = assignment
     increment_assignment_count(startup, 'total_reads', read_counts)
-    
+
+
 class AllocationAnalyzer(object):
     def __init__(self):
         self.judges = {}
@@ -54,15 +55,15 @@ class AllocationAnalyzer(object):
                         role_distribution,
                         program_match,
                         industry_match]
-        
+
     def read_scenario_from_csv(self, input_file):
         with open(input_file) as file:
             reader = DictReader(file)
             self.process_scenario_from_csv(reader)
-        
+
     def read_allocations_from_csv(self, input_file):
         with open(input_file) as file:
-            reader = DictReader(file)            
+            reader = DictReader(file)
             self.process_allocations_from_csv(reader)
 
     def process_scenario_from_csv(self, reader):
@@ -75,25 +76,24 @@ class AllocationAnalyzer(object):
                 self.startups[startup['name']] = startup
             else:
                 print("Couldn't read row: %s" % ",".join(row))
-                
+
     def process_allocations_from_csv(self, reader):
         for row in reader:
             judge = self.judges.get(row['subject'])
             startup = self.startups.get(row['object'])
             if row['action'] == "assigned":
                 self.assigned.append(Assignment(judge, startup))
-                
+
             elif row['action'] == "finished":
                 self.completed.append(Assignment(judge, startup))
-    
-                               
+
     def analyze(self, assignments):
         read_counts = {startup['name']: defaultdict(int)
-                    for startup in self.startups.values()}
+                       for startup in self.startups.values()}
         for assignment in assignments:
             for metric_fn in self.metrics:
                 metric_fn(assignment, read_counts)
-        
+
         return read_counts
 
     def summarize(self, read_counts):
@@ -113,10 +113,11 @@ class AllocationAnalyzer(object):
             summary['max %s' % metric] = val
         for metric, val in list(mins.items()):
             summary['min %s' % metric] = -val
-        
-        summary['total_applications'] = total_applications        
+
+        summary['total_applications'] = total_applications
         summary['total_judges'] = total_judges
         return summary
+
 
 def quick_setup():
     aa = AllocationAnalyzer()

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -22,8 +22,6 @@ class Allocator(object):
         self.judges = []
         self.startups = []
         self.heuristic = find_heuristic(heuristic)
-        Event(action="heuristic",
-              subject=self.heuristic.name)
 
     def _file(self):
         if self.filepath is None:
@@ -50,10 +48,6 @@ class Allocator(object):
             self.assign_startups(judge)
             if judge.remaining <= 0 and not judge.startups:
                 self.judges.remove(judge)
-        description = "{} heuristic is done.".format(self.heuristic.name)
-        Event(action="done",
-              subject="allocate.py",
-              description=description)
 
     def assign_startups(self, judge):
         while judge.needs_another_startup():

--- a/classes/allocator.py
+++ b/classes/allocator.py
@@ -10,7 +10,6 @@ import sys
 from random import choice
 
 from classes.assignments import assign
-from classes.event import Event
 from classes.heuristic import find_heuristic
 from classes.judge import Judge
 from classes.startup import Startup

--- a/classes/bin.py
+++ b/classes/bin.py
@@ -1,5 +1,4 @@
 from classes.assignments import has_been_assigned
-from classes.event import Event
 
 
 BIN_NO_WEIGHT = 0

--- a/classes/bin.py
+++ b/classes/bin.py
@@ -16,19 +16,6 @@ class Bin(object):
     def __str__(self):
         return "Generic Bin"
 
-    def status(self):
-        action = "success"
-        object = ""
-        description = "Is empty"
-        if self.queue:
-            action = "fail"
-            object = self.queue[0]
-            description = "{} unread".format(len(self.queue))
-        Event(action=action,
-              subject=self,
-              object=object,
-              description=description)
-
     def add_startup(self, startup):
         result = self.match(startup)
         if result:

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -53,7 +53,7 @@ class Entity(object):
         return "%s-%s" % (self.type, self.properties['id'])
 
     def __getitem__(self, key):
-        return self.properties.get(key, "BLANK")
+        return self.properties.get(key, "")
 
 
 def csv_output(entities):

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -51,10 +51,11 @@ class Entity(object):
 
     def _generated_name(self):
         return "%s-%s" % (self.type, self.properties['id'])
-        
+
     def __getitem__(self, key):
         return self.properties.get(key, "BLANK")
-    
+
+
 def csv_output(entities):
     print(CSV_HEADER)
     for entity in entities:

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -52,6 +52,8 @@ class Entity(object):
     def _generated_name(self):
         return "%s-%s" % (self.type, self.properties['id'])
         
+    def __getitem__(self, key):
+        return self.properties.get(key, "BLANK")
     
 def csv_output(entities):
     print(CSV_HEADER)

--- a/classes/event.py
+++ b/classes/event.py
@@ -15,7 +15,7 @@ class Event(object):
         self.update_headers(kwargs.keys())
 
     def to_csv(self):
-        fields = {field:"" for field in self.headers}
+        fields = {field: "" for field in self.headers}
         fields.update(self.fields)
         template = (",".join(["{%s}" % key for key in self.headers]))
         return template.format(**fields)

--- a/classes/event.py
+++ b/classes/event.py
@@ -1,23 +1,40 @@
-from collections import OrderedDict
+from collections import defaultdict
 
 
 class Event(object):
+    headers = ['time']
     all_events = []
     ticks = 0
 
     def __init__(self, **kwargs):
-        self.fields = OrderedDict([("time", Event.ticks),
-                                   ("action", ""),
-                                   ("subject", ""),
-                                   ("object", ""),
-                                   ("description", "")])
+        self.fields = defaultdict(str)
+        self.fields["time"] = Event.ticks
         Event.ticks += 1
         self.fields.update(kwargs)
         Event.all_events.append(self)
+        self.update_headers(kwargs.keys())
 
     def to_csv(self):
-        template = (",".join(["{%s}" % key for key in self.fields.keys()]))
-        return template.format(**self.fields)
+        fields = {field:"" for field in self.headers}
+        fields.update(self.fields)
+        template = (",".join(["{%s}" % key for key in self.headers]))
+        return template.format(**fields)
 
     def update(self, **kwargs):
         self.fields.update(kwargs)
+
+    @classmethod
+    def update_headers(cls, field_names):
+        for field_name in field_names:
+            if field_name not in cls.headers:
+                cls.headers.append(field_name)
+
+    @classmethod
+    def header_row(cls):
+        return ",".join(cls.headers)
+
+    @classmethod
+    def all_events_as_csv(cls):
+        result = [cls.header_row()]
+        result += [event.to_csv() for event in cls.all_events]
+        return "\n".join(result)

--- a/classes/gender_distribution_metric.py
+++ b/classes/gender_distribution_metric.py
@@ -1,0 +1,8 @@
+from classes.metric import Metric
+
+def judge_gender(judge, application):
+    return "Gender '%s'" % judge['gender']
+
+class GenderDistributionMetric(Metric):
+    name = "Gender"
+    output_key = judge_gender

--- a/classes/gender_distribution_metric.py
+++ b/classes/gender_distribution_metric.py
@@ -1,8 +1,14 @@
 from classes.metric import Metric
 
-def judge_gender(judge, application):
-    return "Gender '%s'" % judge['gender']
-
 class GenderDistributionMetric(Metric):
-    name = "Gender"
-    output_key = judge_gender
+    def __init__(self, gender, target):
+        super().__init__()
+        self.gender = gender
+        self.target = target
+
+    def output_key(self):
+        return "Gender '%s'" % self.gender
+
+    def condition(self, judge, application):
+        return judge['gender'] == self.gender
+    

--- a/classes/gender_distribution_metric.py
+++ b/classes/gender_distribution_metric.py
@@ -1,5 +1,6 @@
 from classes.metric import Metric
 
+
 class GenderDistributionMetric(Metric):
     def __init__(self, gender, target):
         super().__init__(target)
@@ -10,4 +11,3 @@ class GenderDistributionMetric(Metric):
 
     def condition(self, judge, application):
         return judge['gender'] == self.gender
-    

--- a/classes/gender_distribution_metric.py
+++ b/classes/gender_distribution_metric.py
@@ -2,9 +2,8 @@ from classes.metric import Metric
 
 class GenderDistributionMetric(Metric):
     def __init__(self, gender, target):
-        super().__init__()
+        super().__init__(target)
         self.gender = gender
-        self.target = target
 
     def output_key(self):
         return "Gender '%s'" % self.gender

--- a/classes/industry_match_metric.py
+++ b/classes/industry_match_metric.py
@@ -1,0 +1,12 @@
+from classes.metric import Metric
+
+def industry_match(judge, application):
+    return judge['industry'] == application['industry']
+
+def industry_key(judge, application):
+    return "Matching Industry"
+
+
+class IndustryMatchMetric(Metric):
+    output_key = industry_key
+    condition = industry_match

--- a/classes/industry_match_metric.py
+++ b/classes/industry_match_metric.py
@@ -1,8 +1,9 @@
 from classes.metric import Metric
 
+
 class IndustryMatchMetric(Metric):
     def condition(self, judge, application):
         return judge['industry'] == application['industry']
 
     def output_key(self):
-        return "Matching Industry"        
+        return "Matching Industry"

--- a/classes/industry_match_metric.py
+++ b/classes/industry_match_metric.py
@@ -1,12 +1,8 @@
 from classes.metric import Metric
 
-def industry_match(judge, application):
-    return judge['industry'] == application['industry']
-
-def industry_key(judge, application):
-    return "Matching Industry"
-
-
 class IndustryMatchMetric(Metric):
-    output_key = industry_key
-    condition = industry_match
+    def condition(self, judge, application):
+        return judge['industry'] == application['industry']
+
+    def output_key(self):
+        return "Matching Industry"        

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -14,7 +14,7 @@ class Judge(Entity):
         self.startups = []
         self.type = "judge"
         for property in Property.all_properties:
-            self.add_property(property, data)        
+            self.add_property(property, data)
         self.remaining = int(self.properties.get("commitment", 50))
 
     def complete_startups(self):

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -45,6 +45,3 @@ class Judge(Entity):
     def mark_as_done(self):
         Event(action="done", subject=self)
         self.remaining = 0
-
-    def is_female(self):
-        return self.properties.get('gender', "").startswith('f')

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -15,7 +15,6 @@ class Judge(Entity):
         self.type = "judge"
         for property in Property.all_properties:
             self.add_property(property, data)        
-        self.add_fields_to_name(["industry", "program", "role", "gender"])
         self.remaining = int(self.properties.get("commitment", 50))
 
     def complete_startups(self):
@@ -46,3 +45,6 @@ class Judge(Entity):
     def mark_as_done(self):
         Event(action="done", subject=self)
         self.remaining = 0
+
+    def is_female(self):
+        return self.properties.get('gender', "").startswith('f')

--- a/classes/judge.py
+++ b/classes/judge.py
@@ -14,7 +14,7 @@ class Judge(Entity):
         self.startups = []
         self.type = "judge"
         for property in Property.all_properties:
-            self.add_property(property, data)
+            self.add_property(property, data)        
         self.add_fields_to_name(["industry", "program", "role", "gender"])
         self.remaining = int(self.properties.get("commitment", 50))
 

--- a/classes/judge_role_distribution_metric.py
+++ b/classes/judge_role_distribution_metric.py
@@ -5,14 +5,13 @@ def judge_role(judge, application):
 
 class JudgeRoleDistributionMetric(Metric):
     def __init__(self, role, target):
-        super().__init__()
+        super().__init__(target)
         self.name = "Judge Role"
         self.role = role
-        self.target = target
 
     def output_key(self):
         return "Role: %s" % self.role
     
     def condition(self, judge, application):
-        return judge['role'] == role
+        return judge['role'] == self.role
     

--- a/classes/judge_role_distribution_metric.py
+++ b/classes/judge_role_distribution_metric.py
@@ -4,5 +4,15 @@ def judge_role(judge, application):
     return "Judge Role %s" % judge['role']
 
 class JudgeRoleDistributionMetric(Metric):
-    name = "Judge Role"
-    output_key = judge_role
+    def __init__(self, role, target):
+        super().__init__()
+        self.name = "Judge Role"
+        self.role = role
+        self.target = target
+
+    def output_key(self):
+        return "Role: %s" % self.role
+    
+    def condition(self, judge, application):
+        return judge['role'] == role
+    

--- a/classes/judge_role_distribution_metric.py
+++ b/classes/judge_role_distribution_metric.py
@@ -1,0 +1,8 @@
+from classes.metric import Metric
+
+def judge_role(judge, application):
+    return "Judge Role %s" % judge['role']
+
+class JudgeRoleDistributionMetric(Metric):
+    name = "Judge Role"
+    output_key = judge_role

--- a/classes/judge_role_distribution_metric.py
+++ b/classes/judge_role_distribution_metric.py
@@ -1,7 +1,9 @@
 from classes.metric import Metric
 
+
 def judge_role(judge, application):
     return "Judge Role %s" % judge['role']
+
 
 class JudgeRoleDistributionMetric(Metric):
     def __init__(self, role, target):
@@ -11,7 +13,6 @@ class JudgeRoleDistributionMetric(Metric):
 
     def output_key(self):
         return "Role: %s" % self.role
-    
+
     def condition(self, judge, application):
         return judge['role'] == self.role
-    

--- a/classes/metric.py
+++ b/classes/metric.py
@@ -7,13 +7,21 @@ def increment_read_count(application, output_key, counts_dict):
     startup_name = application['name']
     counts_dict[startup_name][output_key] += 1
 
-class Metric(object):    
-    condition = true_func
+class Metric(object):
+    def __init__(self):
+        self.condition = true_func
+        self.satisfied_apps = set()
     
     def evaluate(self, assignment, counts_dict):
         judge, application = assignment
         if self.condition(judge, application):
             increment_read_count(application,
-                                 self.output_key(judge, application),
+                                 self.output_key(),
                                  counts_dict)
-        
+        if self.satisfied(application, counts_dict):
+            self.satisfied_apps.add(application)
+        else:
+            self.satisfied_apps.discard(application)
+            
+    def satisfied(self, application, counts_dict):
+        return True

--- a/classes/metric.py
+++ b/classes/metric.py
@@ -5,10 +5,9 @@ class Metric(object):
         self.total = 0
         self.max_count = 0
 
-
     def condition(self, judge, application):
         return True
-    
+
     def evaluate(self, assignment, counts_dict):
         judge, application = assignment
         if self.condition(judge, application):
@@ -24,12 +23,11 @@ class Metric(object):
     def update_max(self, startup_name, counts_dict):
         app_count = counts_dict[startup_name][self.output_key()]
         self.max_count = max(self.max_count, app_count)
-        
+
     def satisfied(self, application, counts_dict):
-        return counts_dict[application['name']][self.output_key()] >= self.target
+        app_counts = counts_dict[application['name']]
+        return app_counts[self.output_key()] >= self.target
 
     def increment_read_count(self, application, counts_dict):
         startup_name = application['name']
         counts_dict[startup_name][self.output_key()] += 1
-
-        

--- a/classes/metric.py
+++ b/classes/metric.py
@@ -1,0 +1,19 @@
+
+
+def true_func(*args):
+    return True
+
+def increment_read_count(application, output_key, counts_dict):
+    startup_name = application['name']
+    counts_dict[startup_name][output_key] += 1
+
+class Metric(object):    
+    condition = true_func
+    
+    def evaluate(self, assignment, counts_dict):
+        judge, application = assignment
+        if self.condition(judge, application):
+            increment_read_count(application,
+                                 self.output_key(judge, application),
+                                 counts_dict)
+        

--- a/classes/program_match_metric.py
+++ b/classes/program_match_metric.py
@@ -1,8 +1,9 @@
 from classes.metric import Metric
 
+
 class ProgramMatchMetric(Metric):
-    def output_key (self):
+    def output_key(self):
         return "Home Program Reads"
-    
+
     def condition(self, judge, application):
         return judge['program'] == application['program']

--- a/classes/program_match_metric.py
+++ b/classes/program_match_metric.py
@@ -1,0 +1,12 @@
+from classes.metric import Metric
+
+def home_program_match(judge, application):
+    return judge['program'] == application['program']
+
+def home_program_key(judge, application):
+    return "Home Program Reads"
+
+
+class ProgramMatchMetric(Metric):
+    output_key = home_program_key
+    condition = home_program_match

--- a/classes/program_match_metric.py
+++ b/classes/program_match_metric.py
@@ -1,12 +1,8 @@
 from classes.metric import Metric
 
-def home_program_match(judge, application):
-    return judge['program'] == application['program']
-
-def home_program_key(judge, application):
-    return "Home Program Reads"
-
-
 class ProgramMatchMetric(Metric):
-    output_key = home_program_key
-    condition = home_program_match
+    def output_key (self):
+        return "Home Program Reads"
+    
+    def condition(self, judge, application):
+        return judge['program'] == application['program']

--- a/classes/property.py
+++ b/classes/property.py
@@ -10,7 +10,7 @@ class Property(object):
         Property.all_properties.append(self)
 
 
-name = Property("name")
+name = Property("name",)
 gender = Property("gender", [("female", 0.25),
                              ("male", 1.0)])
 

--- a/classes/property.py
+++ b/classes/property.py
@@ -10,7 +10,7 @@ class Property(object):
         Property.all_properties.append(self)
 
 
-name = Property("name",)
+name = Property("name")
 gender = Property("gender", [("female", 0.25),
                              ("male", 1.0)])
 

--- a/classes/total_reads_metric.py
+++ b/classes/total_reads_metric.py
@@ -1,8 +1,6 @@
 from classes.metric import Metric
 
-def industry_key(judge, application):
-    return "Total Reads"
-
 class TotalReadsMetric(Metric):
-    output_key = industry_key
+    def output_key(self):
+        return "Total Reads"
 

--- a/classes/total_reads_metric.py
+++ b/classes/total_reads_metric.py
@@ -1,0 +1,8 @@
+from classes.metric import Metric
+
+def industry_key(judge, application):
+    return "Total Reads"
+
+class TotalReadsMetric(Metric):
+    output_key = industry_key
+

--- a/classes/total_reads_metric.py
+++ b/classes/total_reads_metric.py
@@ -1,6 +1,6 @@
 from classes.metric import Metric
 
+
 class TotalReadsMetric(Metric):
     def output_key(self):
         return "Total Reads"
-


### PR DESCRIPTION
This PR adds a class which reads in a scenario (output from generate.py) and an allocation (output from allocate.py) and 

To test: 
run the allocate.py script on some scenario: `python3 allocate.py example.csv > tmp.out`
in the python shell
import the AllocationAnalyzer and use the `quick_setup` function to load the scenario and allocation:
```
>>> from classes.allocation_analyzer import *
>>> aa = quick_setup()
>>> counts = aa.analyze(aa.completed)
>>> summary = aa.summarize(counts)
>>> print ("\n".join(["%s: %s" %(key, val) for key, val in summary.items()]))
total_reads: 10390
Investor_reads: 1782
female_reads: 2458
Other_reads: 2099
...
```

Some changes to previous functionality:
- summary data removed from allocate.py output in order to allow csv reader to read it
- Event headers are now universal across the class
- pulled out the name munging for startups and judges

Things to do, now, later, or never:
- script this basic interaction
- metrics probably want to be objects
- tighter cohesion with Allocator and Generator (ability to talk to those objects directly rather than using csvs as intermediary)
- better analysis
- we're not dealing with judge niceness yet
- etc

UPDATES:
Added script. `python3 analyze.py` produces summaries of assigned and completed numbers to stdout, takes optional filenames for scenario and allocation csv files. 
Note: I'm assuming that these scripts are not intended as anything but developer shim, so I'm not making a whole lot of effort to make them nice
