### PR TITLE
[AC-5655] Fix issue with OrderedQueue heuristic missing reads due to AC-5571

### DIFF
--- a/app_allocator/classes/reads_criterion.py
+++ b/app_allocator/classes/reads_criterion.py
@@ -13,5 +13,5 @@ class ReadsCriterion(Criterion):
         return ReadNeed(count=self.count)
 
     def add_option(self, option, count, weight):
-        super().add_option(option, count,weight)
+        super().add_option(option, count, weight)
         self.option_specs.add(OptionSpec(option, count, weight))

--- a/app_allocator/classes/reads_criterion.py
+++ b/app_allocator/classes/reads_criterion.py
@@ -13,4 +13,5 @@ class ReadsCriterion(Criterion):
         return ReadNeed(count=self.count)
 
     def add_option(self, option, count, weight):
+        super().add_option(option, count,weight)
         self.option_specs.add(OptionSpec(option, count, weight))

--- a/app_allocator/tests/test_reads_criterion.py
+++ b/app_allocator/tests/test_reads_criterion.py
@@ -1,0 +1,17 @@
+from app_allocator.classes.criterion import (
+    DEFAULT_COUNT,
+    DEFAULT_WEIGHT,
+)
+from app_allocator.classes.reads_criterion import ReadsCriterion
+
+
+class TestReadsCriterion(object):
+    def test_criterion_with_option_specs(self):
+        criterion = ReadsCriterion("reads")
+        expected_count = 4 * DEFAULT_COUNT
+        expected_weight = 2 * DEFAULT_WEIGHT
+        criterion.add_option(option="reads",
+                             count=expected_count,
+                             weight=expected_weight)
+        assert criterion.count == expected_count
+        assert criterion.weight == expected_weight


### PR DESCRIPTION
To test:
- Run `python3 allocate.py example.csv ordered_queues > tmp.out ; python3 analyze.py example.csv tmp.out > analyze.out; grep 'Completed: missed Total Reads' analyze.out`

On development get something like:
Completed: missed Total Reads: 161

On branch get something like:
Completed: missed Total Reads: 7
