### PR TITLE
[AC-5662] Improve sensitivity of Dynamic Matrix heuristic to criteria weights

### DIFF
--- a/app_allocator/classes/dynamic_matrix_heuristic.py
+++ b/app_allocator/classes/dynamic_matrix_heuristic.py
@@ -21,6 +21,7 @@ class DynamicMatrixHeuristic(Heuristic):
     def __init__(self, criteria):
         super().__init__()
         self.criteria = criteria
+        self.find_count = 0
 
     def setup(self, judges, applications):
         self.judges = tuple(judges)
@@ -44,6 +45,24 @@ class DynamicMatrixHeuristic(Heuristic):
     def _calc_judge_capacities(self):
         return {judge: int(judge['commitment'] or 0) for judge in self.judges}
 
+    def evaluate_application(self, app, application_preferences, needs_matrix):
+        index = self.applications.index(app)
+        print(application_preferences.flat[index])
+        print(needs_matrix[index])
+
+    def evaluate_apps(self, apps, application_preferences, needs_matrix):
+        for app in apps:
+            self.evaluate_application(app, application_preferences,
+                                      needs_matrix)
+
+    def find_app_needing_industry(self, exclude):
+        for app in self.applications:
+            if app not in exclude:
+                industry = app.properties["industry"]
+                if all([industry != judge.properties["industry"]
+                        for judge in app.judges]):
+                    return app
+
     def find_n_applications(self, judge, batch_size):
         if len(self.applications) <= batch_size:
             can_assign = self._can_assign_func(judge)
@@ -61,6 +80,11 @@ class DynamicMatrixHeuristic(Heuristic):
             apps = self.choose_n_applications(judge,
                                               application_preferences,
                                               available_batch_size)
+        # if apps:  # self.find_count > 1600
+        #     app = self.find_app_needing_industry(apps)
+        #     import pdb; pdb.set_trace()
+        #     self.find_count = 0
+        self.find_count += 1
         for app in apps:
             self.judge_assignments[judge].append(app)
             self.judge_capacities[judge] -= 1

--- a/app_allocator/classes/dynamic_matrix_heuristic.py
+++ b/app_allocator/classes/dynamic_matrix_heuristic.py
@@ -21,7 +21,6 @@ class DynamicMatrixHeuristic(Heuristic):
     def __init__(self, criteria):
         super().__init__()
         self.criteria = criteria
-        self.find_count = 0
 
     def setup(self, judges, applications):
         self.judges = tuple(judges)
@@ -45,24 +44,6 @@ class DynamicMatrixHeuristic(Heuristic):
     def _calc_judge_capacities(self):
         return {judge: int(judge['commitment'] or 0) for judge in self.judges}
 
-    def evaluate_application(self, app, application_preferences, needs_matrix):
-        index = self.applications.index(app)
-        print(application_preferences.flat[index])
-        print(needs_matrix[index])
-
-    def evaluate_apps(self, apps, application_preferences, needs_matrix):
-        for app in apps:
-            self.evaluate_application(app, application_preferences,
-                                      needs_matrix)
-
-    def find_app_needing_industry(self, exclude):
-        for app in self.applications:
-            if app not in exclude:
-                industry = app.properties["industry"]
-                if all([industry != judge.properties["industry"]
-                        for judge in app.judges]):
-                    return app
-
     def find_n_applications(self, judge, batch_size):
         if len(self.applications) <= batch_size:
             can_assign = self._can_assign_func(judge)
@@ -80,11 +61,6 @@ class DynamicMatrixHeuristic(Heuristic):
             apps = self.choose_n_applications(judge,
                                               application_preferences,
                                               available_batch_size)
-        # if apps:  # self.find_count > 1600
-        #     app = self.find_app_needing_industry(apps)
-        #     import pdb; pdb.set_trace()
-        #     self.find_count = 0
-        self.find_count += 1
         for app in apps:
             self.judge_assignments[judge].append(app)
             self.judge_capacities[judge] -= 1

--- a/app_allocator/classes/field_criterion.py
+++ b/app_allocator/classes/field_criterion.py
@@ -6,7 +6,9 @@ class FieldCriterion(Criterion):
     def __init__(self, name):
         super().__init__(name)
 
-    def add_option(self, option, count=None, weight=None):
+    def add_option(self, option, count, weight):
+        if weight == "":
+            weight = self.weight
         if option:
             self.option_specs.add(OptionSpec(option, count, weight))
         else:

--- a/app_allocator/classes/matching_criterion.py
+++ b/app_allocator/classes/matching_criterion.py
@@ -68,16 +68,3 @@ class MatchingCriterion(FieldCriterion):
             else:
                 needs[(self.name(), spec.option)] = 0.0
         return needs
-
-
-def _shared_options_by_scarcity(options1, options2):
-    '''options1 and options2 are expected to be dictionaries of
-    options with counts.  E.g., {"Israel": 100, "Boston": 200}
-    The result is the set of shared options ordered by the ratio
-    of the count in options1 divided by the count in options2.
-    '''
-    shared_options = set(options1.keys()).intersection(options2.keys())
-    weighted_options = [(options1[option]/float(options2[option]),
-                         option) for option in shared_options]
-    return [OptionSpec(option) for _, option in
-            sorted(weighted_options, key=lambda pair: pair[0])]

--- a/app_allocator/classes/matching_criterion.py
+++ b/app_allocator/classes/matching_criterion.py
@@ -37,8 +37,14 @@ class MatchingCriterion(FieldCriterion):
 
     def _infer_option_specs(self, judges, applications):
         judge_options = self._options_with_counts(judges)
-        application_options = self._options_with_counts(applications)
-        return _shared_options_by_scarcity(judge_options, application_options)
+        judge_keys = set(judge_options.keys())
+        app_options = self._options_with_counts(applications)
+        app_keys = set(app_options.keys())
+        shared_options = judge_keys.intersection(app_keys)
+        weighted_options = [(judge_options[option]/float(app_options[option]),
+                             option) for option in shared_options]
+        return [OptionSpec(option=option, weight=self.weight) for _, option in
+                sorted(weighted_options, key=lambda pair: pair[0])]
 
     @classmethod
     def set_up_all(cls, judges, applications):
@@ -57,7 +63,7 @@ class MatchingCriterion(FieldCriterion):
     def initial_needs(self, application):
         needs = OrderedDict()
         for spec in self.option_specs:
-            if application[self.name] == spec.option:
+            if application[self.name()] == spec.option:
                 needs[(self.name(), spec.option)] = float(spec.count)
             else:
                 needs[(self.name(), spec.option)] = 0.0

--- a/app_allocator/tests/test_dynamic_matrix_heuristic.py
+++ b/app_allocator/tests/test_dynamic_matrix_heuristic.py
@@ -57,7 +57,7 @@ class TestDynamicMatrixHeuristic(object):
 
     def test_process_pass_judge_event_does_not_change_app_needs(self):
         application, judge, allocator = self._process_judge_event("pass")
-        _assert_needs(application, judge, allocator, 0)
+        _assert_needs(application, judge, allocator, -ASSIGNED_VALUE)
 
     def _process_judge_event(self, action):
         allocator = _allocator()

--- a/app_allocator/tests/test_matching_criterion.py
+++ b/app_allocator/tests/test_matching_criterion.py
@@ -13,7 +13,7 @@ class TestMatchingCriterion(object):
 
     def test_criterion_with_option_specs(self):
         criterion = MatchingCriterion("program")
-        criterion.add_option(option="Boston", count=1)
+        criterion.add_option(option="Boston", count=1, weight=1)
         assert criterion.option_states(Application({"program": "Boston"}))
 
     def test_criterion_without_option_specs(self):

--- a/criteria.csv
+++ b/criteria.csv
@@ -1,9 +1,9 @@
 type,name,count,weight,option
 reads,reads,4,1,
-matching,industry,1,1,
-matching,program,1,1,
-judge,role,2,1,Executive
-judge,role,1,1,Investor
-judge,role,1,1,Lawyer
-judge,gender,1,1,female
-judge,gender,1,1,male
+matching,industry,1,0.9,
+matching,program,1,0.8,
+judge,role,2,0.7,Executive
+judge,role,1,0.6,Investor
+judge,role,1,0.6,Lawyer
+judge,gender,1,0.5,female
+judge,gender,1,0.4,male


### PR DESCRIPTION
To test:
- Run `python3 allocate.py example.csv dynamic_matrix > tmp.out ; python3 analyze.py example.csv tmp.out > analyze.out; grep 'Completed: missed' analyze.out`
- On development see bad results.
- On the branch see pretty good results.
- Increase the weight of female reads in criteria.csv to see even better results.
